### PR TITLE
Fix: Exception on offline machines for overcomitment calculation

### DIFF
--- a/provider/vcomputer/Get-IcingaVirtualComputerInfo.psm1
+++ b/provider/vcomputer/Get-IcingaVirtualComputerInfo.psm1
@@ -410,6 +410,11 @@ function Get-IcingaVirtualComputerInfo() {
         foreach ($VchardDisk in $VComputerHardDisks.Keys) {
             $OvercommitCalculated = $FALSE;
             $PhysicalDisk         = $VComputerHardDisks[$VchardDisk];
+
+            if ([string]::IsNullOrEmpty($details.Partition)) {
+                continue;
+            }
+
             if ($PhysicalDisk.DriveReference.ContainsKey($details.Partition) -eq $FALSE) {
                 continue;
             }


### PR DESCRIPTION
Fixes an exception by calculcating overcomitment status information, which failes for offline machines bebause no drive reference is stored in the VM status

Fixes #27