### PR TITLE
Fix: Wrong unknown on empty overcommit checks

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -6,6 +6,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-hyperv/milestones?state=closed).
 
+## 1.1.0 (2021-09-07)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-hyperv/milestone/2?closed=1)
+
+### Bugfixes
+
+* [#41](https://github.com/Icinga/icinga-powershell-hyperv/issues/41) Fixes `UNKNOWN` on overcommitment check, in case no virtual machines are present on the host
+
 ## 1.0.0 (2021-06-10)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-hyperv/milestone/1?closed=1)

--- a/plugins/Invoke-IcingaCheckHyperVOverCommitment.psm1
+++ b/plugins/Invoke-IcingaCheckHyperVOverCommitment.psm1
@@ -110,7 +110,7 @@ function Invoke-IcingaCheckHyperVOverCommitment()
     $HypervServer                  = Get-IcingaVirtualComputerInfo -IncludeVms $IncludeVms -ExcludeVms $ExcludeVms -ActiveVms:$ActiveVms;
 
     # Create a CheckPackage for storage Overcommitment
-    $OvercommitCheckPackage = New-IcingaCheckPackage -Name 'StorageOverCommit' -OperatorAnd -Verbose $Verbosity;
+    $OvercommitCheckPackage = New-IcingaCheckPackage -Name 'StorageOverCommit' -OperatorAnd -Verbose $Verbosity -IgnoreEmptyPackage;
     # When we are at StorageOvercommitment, we have to go through all available partitions and build CheckPackages
     foreach ($storage in $HypervServer.Resources.StorageOverCommit.Keys) {
         $StorageOverCommit = $HypervServer.Resources.StorageOverCommit[$storage];
@@ -166,7 +166,7 @@ function Invoke-IcingaCheckHyperVOverCommitment()
     $CheckPackage.AddCheck($OvercommitCheckPackage);
 
     # Create a CheckPackage for RAM Overcommitment
-    $OvercommitCheckPackage = New-IcingaCheckPackage -Name 'RAMOverCommit' -OperatorAnd -Verbose $Verbosity;
+    $OvercommitCheckPackage = New-IcingaCheckPackage -Name 'RAMOverCommit' -OperatorAnd -Verbose $Verbosity -IgnoreEmptyPackage;
     # Add Bytes RAMOvercommit IcingaCheck
     $OvercommitCheckPackage.AddCheck(
         (
@@ -203,7 +203,7 @@ function Invoke-IcingaCheckHyperVOverCommitment()
     $CheckPackage.AddCheck($OvercommitCheckPackage);
 
     # Create a CheckPackage for CPU Overcommitment
-    $OvercommitCheckPackage = New-IcingaCheckPackage -Name 'CPUOverCommit' -OperatorAnd -Verbose $Verbosity;
+    $OvercommitCheckPackage = New-IcingaCheckPackage -Name 'CPUOverCommit' -OperatorAnd -Verbose $Verbosity -IgnoreEmptyPackage;
     # Add CPU Cores overcommitment CheckPackage
     $OvercommitCheckPackage.AddCheck(
         (


### PR DESCRIPTION
In case overcommitments are not available or no machines are present, the check should not return UNKNOWN for empty checks but simply ok.