### PR TITLE
Fix: JEA native support without ScriptBlocks

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#41](https://github.com/Icinga/icinga-powershell-hyperv/issues/41) Fixes `UNKNOWN` on overcommitment check, in case no virtual machines are present on the host
 * [#49](https://github.com/Icinga/icinga-powershell-hyperv/issues/49) Fixes an exception in case machines on the system are present with the identical name
 * [#53](https://github.com/Icinga/icinga-powershell-hyperv/pull/53) Fixes exception in case no permission is granted to snapshot directory
+* [#55](https://github.com/Icinga/icinga-powershell-hyperv/pull/55) Fixes JEA error which detected `ScriptBlocks` in the plugin collection
 
 ### Enhancements
 

--- a/icinga-powershell-hyperv.psd1
+++ b/icinga-powershell-hyperv.psd1
@@ -7,7 +7,7 @@
     Description       = 'A collection of Hyper-V plugins, which serve to monitor Hyper-V systems'
     PowerShellVersion = '4.0'
     RequiredModules   = @(
-        @{ModuleName = 'icinga-powershell-framework'; ModuleVersion = '1.5.0' },
+        @{ModuleName = 'icinga-powershell-framework'; ModuleVersion = '1.8.0' },
         @{ModuleName = 'icinga-powershell-plugins'; ModuleVersion = '1.5.0' }
     )
     NestedModules     = @(

--- a/provider/vcomputer/Get-IcingaVirtualComputerInfo.psm1
+++ b/provider/vcomputer/Get-IcingaVirtualComputerInfo.psm1
@@ -282,7 +282,7 @@ function Get-IcingaVirtualComputerInfo()
         }
 
         # Sort our Snapshots based on the creation Time
-        $details.Snapshots.List = $details.Snapshots.List | Sort-Object -Property @{Expression = { [datetime]$_.CreationTime }; Descending = $TRUE };
+        $details.Snapshots.List = $details.Snapshots.List | ConvertTo-IcingaSecureSortedArray -MemberName 'CreationTime' -Descending;
 
         # We are going to loop through all available vm partitions
         foreach ($vmPartition in $VmPartitionsPath) {


### PR DESCRIPTION
Fixes the Hyper-V plugin collection by replacing the previous detected `ScriptBlock` function with a custom function for sorting arrays, increasing security and getting rid of ScriptBlocks within plugin and module context.