### PR TITLE
Fix: Memory OC values and CPU overcommitment

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -18,6 +18,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 * [#52](https://github.com/Icinga/icinga-powershell-hyperv/issues/52) Fixes `This argument does not support the % unit` for `Total Snapshot Size`, caused by duplicate entry
 * [#53](https://github.com/Icinga/icinga-powershell-hyperv/pull/53) Fixes exception in case no permission is granted to snapshot directory
 * [#55](https://github.com/Icinga/icinga-powershell-hyperv/pull/55) Fixes JEA error which detected `ScriptBlocks` in the plugin collection
+* [#57](https://github.com/Icinga/icinga-powershell-hyperv/pull/57) Fixes memory unit which was calculated in `MB` instead of `Bytes` and fixes CPU overcommitment, which could result in negative usage values if there is not overcommitment
 
 ### Enhancements
 

--- a/provider/vcomputer/Get-IcingaVirtualComputerInfo.psm1
+++ b/provider/vcomputer/Get-IcingaVirtualComputerInfo.psm1
@@ -341,10 +341,10 @@ function Get-IcingaVirtualComputerInfo()
                 $details.Add('DynamicMemoryAllocated', $memory.DynamicMemoryEnabled);
 
                 if ($memory.DynamicMemoryEnabled) {
-                    $VComputerData.Resources.RAMOverCommit.Bytes += $memory.Limit;
+                    $VComputerData.Resources.RAMOverCommit.Bytes += ($memory.Limit * 1024 * 1024);
                     $details.Add('MemoryCapacity', $memory.Limit);
                 } else {
-                    $VComputerData.Resources.RAMOverCommit.Bytes += $memory.VirtualQuantity;
+                    $VComputerData.Resources.RAMOverCommit.Bytes += ($memory.VirtualQuantity * 1024 * 1024);
                     $details.Add('MemoryCapacity', $memory.VirtualQuantity);
                 }
             }
@@ -535,6 +535,10 @@ function Get-IcingaVirtualComputerInfo()
         $VComputerData.Resources.CPUOverCommit.Percent = 100;
     } else {
         $VComputerData.Resources.CPUOverCommit.Percent = ([System.Math]::Round((($VComputerData.Resources.CPUOverCommit.Cores / $CountCPUCores) * 100) - 100, 2));
+
+        if ($VComputerData.Resources.CPUOverCommit.Percent -le 0) {
+            $VComputerData.Resources.CPUOverCommit.Percent = 0;
+        }
     }
 
     $VComputerData.Summary.AccessDeniedVms = $AccessDeniedVms;
@@ -542,6 +546,7 @@ function Get-IcingaVirtualComputerInfo()
     $VComputerData.Summary.TotalVms = ($VComputerData.Summary.RunningVms + $VComputerData.Summary.StoppedVms);
     # Calculate the average Hyper-V RAM Overcommitment
     $RAMUsedPercent = ([System.Math]::Round((($VComputerData.Resources.RAMOverCommit.Bytes / $VComputerRamLimit) * 100) - 100, 2));
+
     if ($RAMUsedPercent -le 0) {
         $RAMUsedPercent = 0;
     }


### PR DESCRIPTION
Fixes memory overcommitment base value which was not in bytes before and fixes CPU overcommitment which would add negative values for percent usage instead of 0, in case we are not overcommitet.