### PR TITLE
Fix: Hyper-V Health plugin always reporting critical because of service exit code 1077

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -11,6 +11,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-hyperv/milestone/3?closed=1)
 
+### Bugfixes
+
+* [#64](https://github.com/Icinga/icinga-powershell-hyperv/issues/64) Fixes Hyper-V Health plugin always reporting critical because of service exit code `1077`, which simply means this service was never started on the host before and can safely be ignored
+
 ### Enhancements
 
 * [#60](https://github.com/Icinga/icinga-powershell-hyperv/issues/60) Adds support for providing a different `Username` and `Password` for `Invoke-IcingaCheckHyperVVMM`, to run the check as different user

--- a/plugins/Invoke-IcingaCheckHyperVHealth.psm1
+++ b/plugins/Invoke-IcingaCheckHyperVHealth.psm1
@@ -77,7 +77,8 @@ function Invoke-IcingaCheckHyperVHealth()
             -MetricIndex $Service `
             -MetricName 'state';
 
-        if (([string]::IsNullOrEmpty($HypervService.configuration.ExitCode) -eq $FALSE) -And ($HypervService.configuration.ExitCode -ne 0) -And ($HypervService.configuration.Status.raw -ne $ProviderEnums.ServiceStatus.Running)) {
+        # Ensure exit code 1077 is ignored, as this means the service was never started: https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--1000-1299-
+        if (([string]::IsNullOrEmpty($HypervService.configuration.ExitCode) -eq $FALSE) -And ($HypervService.configuration.ExitCode -ne 0 -And $HypervService.configuration.ExitCode -ne 1077) -And ($HypervService.configuration.Status.raw -ne $ProviderEnums.ServiceStatus.Running)) {
             $Check.CritIfNotMatch($ProviderEnums.ServiceStatus.Running) | Out-Null;
         } elseif (($Service -eq 'vmcompute' -Or $Service -eq 'vmms') -And ($HypervService.configuration.Status.raw -ne $ProviderEnums.ServiceStatus.Running)) {
             $Check.CritIfNotMatch($ProviderEnums.ServiceStatus.Running) | Out-Null;


### PR DESCRIPTION
Fixes Hyper-V Health plugin always reporting critical because of service exit code 1077, which simply means this service was never started on the host before.

It should be save to ignore and actuall makes the plugin useful.

Ressource: https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--1000-1299-