### PR TITLE
Fixes slow Hyper-V check performance on cluster environments

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -16,6 +16,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-hyperv/milestone/6?closed=1)
 
 * [#77](https://github.com/Icinga/icinga-powershell-hyperv/issues/77) Fixes exception on Hyper-V checks in case no virtual machine is returned, found or filtered out
+* [#79](https://github.com/Icinga/icinga-powershell-hyperv/pull/79) Fixes `Get-IcingaVirtualComputerInfo` to only call `Get-IcingaClusterSharedVolumeData` once and not for each partition of a virtual machine
 
 ## 1.3.0 (2023-11-02)
 

--- a/provider/vcomputer/Get-IcingaVirtualComputerInfo.psm1
+++ b/provider/vcomputer/Get-IcingaVirtualComputerInfo.psm1
@@ -53,6 +53,7 @@ function Get-IcingaVirtualComputerInfo()
     $VComputerRamLimit      = (Get-IcingaMemoryPerformanceCounter).'Memory Total Bytes';
     $PluginInstalled        = $FALSE;
     $CurrentVmsUsage        = 0;
+    $ClusterSharedVolume    = @{ };
     [array]$AccessDeniedVms = @();
     $VComputerData          = @{
         'VMs'       = @{ };
@@ -94,7 +95,8 @@ function Get-IcingaVirtualComputerInfo()
     }
 
     if (Test-IcingaFunction 'Get-IcingaClusterSharedVolumeData') {
-        $PluginInstalled = $TRUE;
+        $PluginInstalled     = $TRUE;
+        $ClusterSharedVolume = Get-IcingaClusterSharedVolumeData;
     }
 
     foreach ($vcomputer in $VirtualComputers) {
@@ -452,7 +454,6 @@ function Get-IcingaVirtualComputerInfo()
                         $VComputerData.Summary.Add('Located', 'ClusterStorage');
                     }
                 } else {
-                    $ClusterSharedVolume = Get-IcingaClusterSharedVolumeData;
                     foreach ($volume in $ClusterSharedVolume.Keys) {
                         $SharedVolume     = $ClusterSharedVolume[$volume];
                         [string]$VolumeId = $SharedVolume.SharedVolumeInfo.FriendlyVolumeName;
@@ -522,7 +523,6 @@ function Get-IcingaVirtualComputerInfo()
                     $VComputerData.Summary.Add('SnapshotLocated', 'ClusterStorage');
                 }
             } else {
-                $ClusterSharedVolume = Get-IcingaClusterSharedVolumeData;
                 foreach ($volume in $ClusterSharedVolume.Keys) {
                     $SharedVolume     = $ClusterSharedVolume[$volume];
                     [string]$VolumeId = $SharedVolume.SharedVolumeInfo.FriendlyVolumeName;


### PR DESCRIPTION
Fixes Get-IcingaVirtualComputerInfo to only call Get-IcingaClusterSharedVolumeData once and not for each partition of a virtual machine