### PR TITLE
Fix: Exception on Hyper-V Snapshot checks with no VMs

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -11,6 +11,12 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-hyperv/milestone/5?closed=1)
 
+## 1.3.1 (2025-01-31)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-hyperv/milestone/6?closed=1)
+
+* [#77](https://github.com/Icinga/icinga-powershell-hyperv/issues/77) Fixes exception on Hyper-V checks in case no virtual machine is returned, found or filtered out
+
 ## 1.3.0 (2023-11-02)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-hyperv/milestone/4?closed=1)

--- a/provider/vcomputer/Get-IcingaVirtualComputerInfo.psm1
+++ b/provider/vcomputer/Get-IcingaVirtualComputerInfo.psm1
@@ -502,7 +502,7 @@ function Get-IcingaVirtualComputerInfo()
     }
 
     if ($VComputerData.VMs.Count -eq 0) {
-        return;
+        return $VirtualComputers;
     }
 
     foreach ($vm in $VComputerData.VMs.Keys) {


### PR DESCRIPTION
Fixes exception on Hyper-V checks in case no virtual machine is returned, found or filtered out

Fixes #77